### PR TITLE
fix(readme): Remove Typescript info

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,4 @@ Then run:
 $ ionic start myApp --v2
 ```
 
-Or for TypeScript:
-```bash
-$ ionic start myApp --v2 --ts
-```
-
 More info on this can be found on the Ionic 2 [Getting Started](http://ionicframework.com/docs/v2/getting-started/) page.


### PR DESCRIPTION
Ionic CLI Beta 32 and up no longer support the --ts flag on the start command because typescript is now default so this README should no longer instruct developers to use the --ts flag
